### PR TITLE
Allow skipping of frontend maven plugin

### DIFF
--- a/UI/pom.xml
+++ b/UI/pom.xml
@@ -11,6 +11,10 @@
     <artifactId>Hygieia</artifactId>
     <version>2.0.4-SNAPSHOT</version>
   </parent>
+	
+  <properties>
+    <frontend-maven-plugin.skip>false</frontend-maven-plugin.skip>	  
+  </properties>
 
   <build>
     <plugins>
@@ -57,6 +61,7 @@
 
 				<configuration>
 					<workingDirectory>./</workingDirectory>
+					<skip>${frontend-maven-plugin.skip}</skip>
 				</configuration>
 
 				<executions>


### PR DESCRIPTION
The frontend-maven-plugin downloads node from an Internet repository and installs for execution. This may not be feasible for all consumers.

This merge request allows configuration of skipping the frontend-maven-plugin, defaulting to false (in other words, it executes by default).
